### PR TITLE
edmg is uninitialized causing a CPU WARN 

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -339,6 +339,7 @@ static u8 rtw_chbw_to_cfg80211_chan_def(struct wiphy *wiphy, struct cfg80211_cha
 	chdef->chan = chan;
 	chdef->center_freq1 = cfreq;
 	chdef->center_freq2 = 0;
+	memset(&chdef->edmg, 0, sizeof(chdef->edmg));
 
 	ret = _SUCCESS;
 


### PR DESCRIPTION
Zeroing out chdef->edmg in rtw_chbw_to_cfg80211_chan_def. There are some checks later to see if edmg is valid. If edmg.channels is defined it will fail the validity check if the rest of the structure isn't correct.