### PR TITLE
`uname -m` = aarch64 -> arch/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1302,7 +1302,7 @@ endif
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/)
+SUBARCH := $(shell uname -m | sed -e 's/i.86/i386/;s/aarch64/arm64/')
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER  := $(shell uname -r)


### PR DESCRIPTION
Fixes ability to compile in dkms on aarch64.