### PR TITLE
Add implicit-fallthrough flag to Makefile in comment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ EXTRA_CFLAGS += -O2
 #EXTRA_CFLAGS += -Werror
 #EXTRA_CFLAGS += -pedantic
 #EXTRA_CFLAGS += -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
+#EXTRA_CFLAGS += -Wimplicit-fallthrough=1
 
 EXTRA_CFLAGS += -Wno-unused-variable
 #EXTRA_CFLAGS += -Wno-unused-value


### PR DESCRIPTION
This flag prevents many warnings by allowing the compiler to recognize
the "fall through" comments.