### PR TITLE
Fixing random disconnect issue

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -427,11 +427,17 @@ int rtw_hwpwrp_detect = 1;
 int rtw_hwpwrp_detect = 0; /* HW power  ping detect 0:disable , 1:enable */
 #endif
 
-#ifdef CONFIG_USB_HCI
-int rtw_hw_wps_pbc = 1;
-#else
+
+/*
+Causes excessive rescanning by nature of WPS, the "Push Button Configuration"
+	being something initialized on the access point by button due to the 
+	traditionally non-graphical nature of routers. This should only be enabled
+	during those events, otherwise the radio(s) will have to drop beam forming
+	capabilities to do a general scan for an access point emitting the unsecured
+	connection information.
+*/
 int rtw_hw_wps_pbc = 0;
-#endif
+
 
 #ifdef CONFIG_80211D
 int rtw_80211d = 0;


### PR DESCRIPTION
It looks like re-scans but it isn't, it's WPS being left on and forcibly changing the transmission type and maybe crashing the beam-forming interface. This is a huge security issue and should probably be fixed immediately. It can be configured with `rtw_hw_wps_pbc=` either `0` for off or `1` for on.

As a side note, **all current drivers** for the Archer T4U Plus device do this wrong to different levels. Last night, the radio was so far away from a proper state (on a set of drivers for the `rtl8812au`, which is a bit worse here) that it changed a strip of ceiling lights that are just white to an animated mode. **The remote for these broke a long time ago so it's quite impressive how wrong the 2.4 GHz signal came out here.**

This fixes the issue [here](https://github.com/RinCat/RTL88x2BU-Linux-Driver/issues/198#issuecomment-1592199769).