### PR TITLE
fix netdev (un)registration deadlock

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -5060,7 +5060,11 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	mon_wdev->iftype = NL80211_IFTYPE_MONITOR;
 	mon_ndev->ieee80211_ptr = mon_wdev;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+	ret = cfg80211_register_netdevice(mon_ndev);
+#else
 	ret = register_netdevice(mon_ndev);
+#endif
 	if (ret)
 		goto out;
 
@@ -6762,7 +6766,11 @@ static int cfg80211_rtw_del_virtual_intf(struct wiphy *wiphy,
 		pwdev_priv = adapter_wdev_data(adapter);
 
 		if (ndev == pwdev_priv->pmon_ndev) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+			cfg80211_unregister_netdevice(ndev);
+#else
 			unregister_netdevice(ndev);
+#endif
 			pwdev_priv->pmon_ndev = NULL;
 			pwdev_priv->ifname_mon[0] = '\0';
 			RTW_INFO(FUNC_NDEV_FMT" remove monitor ndev\n", FUNC_NDEV_ARG(ndev));

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -2192,7 +2192,11 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	if (rtnl_lock_needed)
 		ret = (register_netdev(ndev) == 0) ? _SUCCESS : _FAIL;
 	else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+		ret = (cfg80211_register_netdevice(ndev) == 0) ? _SUCCESS : _FAIL;
+#else
 		ret = (register_netdevice(ndev) == 0) ? _SUCCESS : _FAIL;
+#endif
 
 	if (ret == _SUCCESS)
 		adapter->registered = 1;
@@ -2241,7 +2245,11 @@ void rtw_os_ndev_unregister(_adapter *adapter)
 		if (rtnl_lock_needed)
 			unregister_netdev(netdev);
 		else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+			cfg80211_unregister_netdevice(netdev);
+#else
 			unregister_netdevice(netdev);
+#endif
 	}
 
 #if defined(CONFIG_IOCTL_CFG80211) && !defined(RTW_SINGLE_WIPHY)


### PR DESCRIPTION
Fix deadlock on `iw dev wlan0 del` (this happen at least in OpenWRT during wifi re-configuration process).

Fix description from linux kernel [maillist](https://patchwork.kernel.org/project/linux-wireless/patch/20210122161942.cf2f4b65e4e9.Ida8234e50da13eb675b557bac52a713ad4eddf71@changeid/):
```
We used to not require anything in terms of registering netdevs
with cfg80211, using a netdev notifier instead. However, in the
next patch reducing RTNL locking, this causes big problems, and
the simplest way is to just require drivers to do things better.

Change the registration/unregistration semantics to require the
drivers to call cfg80211_(un)register_netdevice() when this is
happening due to a cfg80211 request, i.e. add_virtual_intf() or
del_virtual_intf() (or if it somehow has to happen in any other
cfg80211 callback).
```