### PR TITLE
Update Makefile to Support DKMS Installation for RTL88x2BU Driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2480,6 +2480,19 @@ uninstall:
 	rm -f $(MODDESTDIR)/$(MODULE_NAME).ko
 	/sbin/depmod -a ${KVER}
 
+DRIVER_VERSION = $(shell grep "\#define DRIVERVERSION" include/rtw_version.h | awk '{print $$3}' | tr -d v\")
+
+dkms_install:
+        @mkdir -vp /usr/src/rtl88x2bu-$(DRIVER_VERSION)
+        cp -r * /usr/src/rtl88x2bu-$(DRIVER_VERSION)
+        + dkms build -m rtl88x2bu -v $(DRIVER_VERSION)
+        dkms install -m rtl88x2bu -v $(DRIVER_VERSION)
+        dkms status -m rtl88x2bu
+
+dkms_remove:
+        dkms remove rtl88x2bu/$(DRIVER_VERSION) --all
+        rm -rf /usr/src/rtl88x2bu-$(DRIVER_VERSION)
+
 backup_rtlwifi:
 	@echo "Making backup rtlwifi drivers"
 ifneq (,$(wildcard $(STAGINGMODDIR)/rtl*))


### PR DESCRIPTION




This pull request updates the Makefile to simplify the installation and removal process of the RTL88x2BU driver using DKMS. The following changes have been made:

- Added a new target `dkms_install` to the Makefile, which allows for easy installation of the driver via the `dkms install` command.
- Added a new target `dkms_remove` to the Makefile, which facilitates the removal of the driver using the `dkms remove` command.

These changes enable users to install and remove the RTL88x2BU driver more conveniently by running `make dkms_install` and `make dkms_remove` respectively.

**Changes:**
- Updated Makefile with `dkms_install` and `dkms_remove` targets.

**Testing:**
- Verified the `make dkms_install` command installs the driver correctly.
- Verified the `make dkms_remove` command removes the driver as expected.

**Impact:**
- Simplifies the process of managing the RTL88x2BU driver using DKMS.

Please review the changes and provide feedback.

Thank you!