### PR TITLE
[Kernel 6.13 Fix] Add additional argument to cfg80211_rtw_set_monitor_channel

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6952,13 +6952,13 @@ static void rtw_get_chbwoff_from_cfg80211_chan_def(
 		rtw_warn_on(1);
 	};
 }
-#endif /*#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))*/
+#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
 
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
 	, struct net_device *dev
-	, struct cfg80211_chan_def *chandef
-#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	, struct cfg80211_chan_def *chandef
 #else
 	, struct ieee80211_channel *chan

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6952,10 +6952,13 @@ static void rtw_get_chbwoff_from_cfg80211_chan_def(
 		rtw_warn_on(1);
 	};
 }
-#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
+#endif /*#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))*/
 
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+	, struct net_device *dev
+	, struct cfg80211_chan_def *chandef
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	, struct cfg80211_chan_def *chandef
 #else
 	, struct ieee80211_channel *chan


### PR DESCRIPTION
In Linux Kernel commit 9c4f83092775 a new argument is introduced to cfg80211_rtw_set_monitor_channel.

_______

Source: https://github.com/cilynx/rtl88x2bu/compare/5.8.7.1_35809.20191129_COEX20191120-7777...fix-linux-6.12