### PR TITLE
Linux 6.18 compat: Drop `hmac_sha256` symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # REALTEK RTL88x2B USB Linux Driver
 **Current Driver Version**: 5.13.1-30
-**Support Kernel**: 2.6.24 ~ 6.15 (with unofficial patches)
+**Support Kernel**: 2.6.24 ~ 6.18 (with unofficial patches)
 
 Linux in-tree rtw8822bu driver is a work in progress. Check [this](https://lore.kernel.org/lkml/20220518082318.3898514-1-s.hauer@pengutronix.de/) patchset.
 

--- a/core/crypto/sha256.c
+++ b/core/crypto/sha256.c
@@ -86,19 +86,3 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 	_len[1] = SHA256_MAC_LEN;
 	return sha256_vector(2, _addr, _len, mac);
 }
-
-
-/**
- * hmac_sha256 - HMAC-SHA256 over data buffer (RFC 2104)
- * @key: Key for HMAC operations
- * @key_len: Length of the key in bytes
- * @data: Pointers to the data area
- * @data_len: Length of the data area
- * @mac: Buffer for the hash (32 bytes)
- * Returns: 0 on success, -1 on failure
- */
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
-		size_t data_len, u8 *mac)
-{
-	return hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
-}

--- a/core/crypto/sha256.h
+++ b/core/crypto/sha256.h
@@ -13,8 +13,6 @@
 
 int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 		       const u8 *addr[], const size_t *len, u8 *mac);
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
-		size_t data_len, u8 *mac);
 int sha256_prf(const u8 *key, size_t key_len, const char *label,
 	       const u8 *data, size_t data_len, u8 *buf, size_t buf_len);
 int sha256_prf_bits(const u8 *key, size_t key_len, const char *label,


### PR DESCRIPTION
The said symbol seems to be unused in driver code, `hmac_sha256_vector` seems to be used instead.

This commit focuses on compatibility with `6.18` and nothing more. It makes it working, it does not fix all warnings that were previously emmited in my `make.log` by DKMS. I also remove the legacy code (`hmac_sha256` seems to be shim for `hmac_sha256_vector`), which might be a breaking change (my editor tells me it's not used anywhere tho but to be cautious I want to emphasize this).

I've also compiled the driver and ran hotspot – seems to be functional when testing on `6.18`.