### PR TITLE
Linux 6.12-lts compat: set_monitor_channel args

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -7052,7 +7052,7 @@ static void rtw_get_chbwoff_from_cfg80211_chan_def(
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
 
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
 	, struct net_device *dev
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))


### PR DESCRIPTION
ref: upstream stable/linux-6.12.y commit 4dae80dd259b5c24f6c657f434afd5de1f791d12