### PR TITLE
Fix interface name registration race

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1873,8 +1873,8 @@ static const struct net_device_ops rtw_netdev_ops = {
 
 int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname)
 {
-#ifdef CONFIG_EASY_REPLACEMENT
 	_adapter *padapter = rtw_netdev_priv(pnetdev);
+#ifdef CONFIG_EASY_REPLACEMENT
 	struct net_device	*TargetNetdev = NULL;
 	_adapter			*TargetAdapter = NULL;
 
@@ -1897,8 +1897,14 @@ int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname)
 	}
 #endif /* CONFIG_EASY_REPLACEMENT */
 
-	if (dev_alloc_name(pnetdev, ifname) < 0)
-		RTW_ERR("dev_alloc_name, fail!\n");
+	if (rtw_rtnl_lock_needed(adapter_to_dvobj(padapter))) {
+		/* register_netdev() will allocate the name under RTNL. */
+		STRSCPY(pnetdev->name, ifname, IFNAMSIZ);
+	} else {
+		/* Caller already holds RTNL; allocate before register_netdevice(). */
+		if (dev_alloc_name(pnetdev, ifname) < 0)
+			RTW_ERR("dev_alloc_name, fail!\n");
+	}
 
 	rtw_netif_carrier_off(pnetdev);
 	/* rtw_netif_stop_queue(pnetdev); */


### PR DESCRIPTION
Driver may fail to initialize and register wlanN when another driver registers the same name wlanN simultaneously.

This happens on my machine in ~10% of reboots with 0bda:b812 Cudy WU1400 AC1300 WiFi USB 3.0 Adapter with this driver only with USB 3.0 switch enabled (88x2bu.rtw_switch_usb_mode=1) and another USB WiFI dongle - 2604:0020 Tenda AIC 8800D80 USB 2.0 - also with out-of-tree driver (https://github.com/shenmintao/aic8800d80) initializing simultaneously. In my case both are trying to register wlan0 and aic8800d80 always wins in a case of 88x2bu failure.

The symptoms are:

1) There is no 88x2bu's interface in `iw dev`
2) Adapter is still present in `lsusb` (and in USB 3.0 mode in a case of
   88x2bu.rtw_switch_usb_mode=1)
3) A WARNING in dmesg:

```
	...
	[   12.949533] ------------[ cut here ]------------
	[   12.949538] WARNING: CPU: 0 PID: 9 at os_dep/linux/os_intfs.c:3770 rtw_os_ndevs_init+0x1e8/0x290 [88x2bu]
	[   12.949669] Modules linked in: 8021q garp btusb btrtl btintel btmtk btbcm bluetooth aic8800_fdrv(O) ecdh_generic ecc nf_conntrack_netbios_ns nf_conntrack_broadcast nft_nat nft_masq nft_fib_inet nft_fib_ipv4 nft_fib_ipv6 nft_fib nft_reject_inet nf_reject_ipv4 nf_reject_ipv6 nft_reject nft_ct nft_chain_nat nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 nf_tables nfnetlink aic_load_fw(O) vhost_vsock vmw_vsock_virtio_transport_common vsock vhost_net tun vhost vhost_iotlb tap bridge stp llc spidev imx477 v4l2_cci regmap_i2c brcmfmac_cyw aes_ce_blk aes_ce_cipher ghash_ce raspberrypi_hwmon gf128mul 88x2bu(O) spi_bcm2835 vc4 brcmfmac snd_soc_hdmi_codec drm_exec drm_display_helper brcmutil cec drm_dma_helper drm_client_lib i2c_brcmstb snd_soc_core rp1_cfe_downstream snd_compress snd_pcm_dmaengine pisp_be snd_seq rpi_hevc_dec v4l2_mem2mem snd_seq_device binfmt_misc cfg80211 v4l2_fwnode videobuf2_dma_contig v4l2_async gpio_keys videobuf2_memops videobuf2_v4l2 v3d snd_pcm rfkill videodev gpio_fan gpu_sched drm_shmem_helper
	[   12.949750]  pwm_fan videobuf2_common snd_timer snd drm_kms_helper mc raspberrypi_gpiomem rp1_pio i2c_designware_platform rp1_fw rp1_adc i2c_designware_core rp1_mailbox nvmem_rmem sch_fq_codel drm i2c_dev drm_panel_orientation_quirks dm_multipath fuse dm_mod backlight bpf_preload
	[   12.949779] CPU: 0 UID: 0 PID: 9 Comm: kworker/0:0 Tainted: G           O        6.18.48-1.rpi5.fc44.aarch64 #1 PREEMPT
	[   12.949785] Tainted: [O]=OOT_MODULE
	[   12.949786] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
	[   12.949789] Workqueue: usb_hub_wq hub_event
	[   12.949800] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
	[   12.949803] pc : rtw_os_ndevs_init+0x1e8/0x290 [88x2bu]
	[   12.949892] lr : rtw_os_ndevs_init+0xb4/0x290 [88x2bu]
	[   12.949970] sp : ffffc000800bb510
	[   12.949972] x29: ffffc000800bb510 x28: ffff8001417aa400 x27: ffff8000c047a000
	[   12.949977] x26: ffffda06170d1ab0 x25: 0000000000000001 x24: ffffc0008946f7f3
	[   12.949981] x23: ffffda06170d1000 x22: ffffc0008946f36c x21: 0000000000000001
	[   12.949984] x20: 0000000000000000 x19: ffff80004011a000 x18: 0000000000000000
	[   12.949988] x17: ffffa5fa1524c000 x16: ffffc00080000000 x15: 0000000000000000
	[   12.949991] x14: ffff800004160090 x13: 0000000000000000 x12: 0000000000000000
	[   12.949995] x11: 00000000000000c0 x10: 0000000000001b00 x9 : ffffda0629834b70
	[   12.949999] x8 : ffff800004161b60 x7 : ffffa5fa1524c000 x6 : ffffc0008828bbd0
	[   12.950002] x5 : ffff80000520e610 x4 : ffff800004161c00 x3 : 0000000000000000
	[   12.950006] x2 : 0000000000000000 x1 : 0000000000000000 x0 : 0000000000000000
	[   12.950010] Call trace:
	[   12.950012]  rtw_os_ndevs_init+0x1e8/0x290 [88x2bu] (P)
	[   12.950091]  rtw_drv_init+0x57c/0x980 [88x2bu]
	[   12.950168]  usb_probe_interface+0xd0/0x2c8
	[   12.950173]  really_probe+0xc4/0x2c8
	[   12.950177]  __driver_probe_device+0x88/0x160
	[   12.950180]  driver_probe_device+0x44/0x188
	[   12.950182]  __device_attach_driver+0xa8/0x138
	[   12.950184]  bus_for_each_drv+0x8c/0xf8
	[   12.950189]  __device_attach+0xa4/0x1a8
	[   12.950191]  device_initial_probe+0x1c/0x30
	[   12.950193]  bus_probe_device+0xa4/0xb0
	[   12.950197]  device_add+0x5ac/0x7c8
	[   12.950200]  usb_set_configuration+0x43c/0xa50
	[   12.950204]  usb_generic_driver_probe+0x5c/0xa0
	[   12.950206]  usb_probe_device+0x48/0x168
	[   12.950209]  really_probe+0xc4/0x2c8
	[   12.950211]  __driver_probe_device+0x88/0x160
	[   12.950213]  driver_probe_device+0x44/0x188
	[   12.950215]  __device_attach_driver+0xa8/0x138
	[   12.950217]  bus_for_each_drv+0x8c/0xf8
	[   12.950220]  __device_attach+0xa4/0x1a8
	[   12.950222]  device_initial_probe+0x1c/0x30
	[   12.950224]  bus_probe_device+0xa4/0xb0
	[   12.950227]  device_add+0x5ac/0x7c8
	[   12.950230]  usb_new_device+0x1ac/0x4f8
	[   12.950235]  hub_event+0xdec/0x1580
	[   12.950238]  process_one_work+0x15c/0x3a8
	[   12.950242]  worker_thread+0x18c/0x2f8
	[   12.950244]  kthread+0x148/0x220
	[   12.950248]  ret_from_fork+0x10/0x20
	[   12.950253] ---[ end trace 0000000000000000 ]---
	...
```

cfg80211_register_netdevice() returns -EEXIST (-17) in this case which is seen if you add a debug printf:

	...
	[   13.166488] AICWFDBG(LOGINFO)	rwnx_interface_add: wlan%d, 2, 10
	[   13.166580] AICWFDBG(LOGINFO)	interface add:e8 65 d4 48 5e 1c
	[   13.171580] AICWFDBG(LOGINFO)	get_txpwr_max:txpwr_max:18
	[   13.171608] AICWFDBG(LOGINFO)	New interface create wlan0
	[   13.171620] RTW: ERROR rtw_os_ndev_register: name=wlan0 requested=wlan%d registration_errno=-17
	[   13.171813] AICWFDBG(LOGINFO)	rwnx_platform_init rwnx_cfg80211_init exit
	[   13.171969] usbcore: registered new interface driver aic8800_fdrv
	[   13.174100] AICWFDBG(LOGINFO)	get_txpwr_max:txpwr_max:18
	[   13.174455] usbcore: registered new interface driver btusb
	[   13.178519] 8021q: 802.1Q VLAN Support v1.8
	[   13.185520] ------------[ cut here ]------------
	[   13.185525] WARNING: CPU: 0 PID: 78 at os_dep/linux/os_intfs.c:3780 rtw_os_ndevs_init+0x1e8/0x290 [88x2bu]
	...

The fix is to call register_netdev() with "wlan%d" and let the kernel allocate a free interface name under a lock instead of allocating it using dev_alloc_name() and then passing the result to register_netdev().